### PR TITLE
Re-name pilot to docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,7 @@
-# 2i2c Hubs as a Service pilot
+# 2i2c Managed Hub Service Documentation
 
 This repository serves as the user-facing documentation and communication space for those who are using 2i2c Hubs.
 
-**Note: This documentation is a work in progress, so please do not hesitate to provide feedback [by opening an issue](https://github.com/2i2c-org/pilot/issues/new).
-
 Most of the infrastructure that we discuss in the documentation is deployed [in the `infrastructure/` repository](https://github.com/2i2c-org/infrastructure).
 
-See [the pilot documentation](https://2i2c.org/pilot) for more information.
+See [the service documentation](https://docs.2i2c.org) for more information.

--- a/about/roadmap.md
+++ b/about/roadmap.md
@@ -12,7 +12,7 @@ Below we describe major initiatives that are currently active in the Managed Hub
 ## Hub infrastructure launch
 
 The Managed Hubs Service relies heavily on infrastructure that centralizes the configuration and deployment of many JupyterHub instances.
-Our first major project is to use [our Pilot JupyterHubs](https://infrastructure.2i2c.org/en/latest/reference/hubs.html) to drive development on this infrastructure stack.
+Our first major project is to use [our alpha JupyterHubs service](https://infrastructure.2i2c.org/en/latest/reference/hubs.html) to drive development on this infrastructure stack.
 
 :::{note}
 We are also [using an issue](https://github.com/2i2c-org/infrastructure/issues/610) to track long-term infrastructure needs for this service across all cloud providers.

--- a/admin/howto/replicate.md
+++ b/admin/howto/replicate.md
@@ -110,7 +110,7 @@ All of the configuration for a 2i2c JupyterHub exists at the [`infrastructure/` 
 There are two main things you'll need from this repository to deploy your hub:
 
 1. **Your hub-specific configuration**. `infrastructure/` contains [configurations for each JupyterHub in YAML files](https://github.com/2i2c-org/infrastructure/tree/master/config/clusters).
-   - Each `yaml` file is a Kubernetes cluster with a collection of hubs on it. The [`2i2c.cluster.yaml` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/2i2c.cluster.yaml) contains most 2i2c hubs that do not have their own dedicated cluster.
+   - Each `yaml` file is a Kubernetes cluster with a collection of hubs on it. The [`2i2c.cluster.yaml` configuration](https://github.com/2i2c-org/infrastructure/blob/master/config/clusters/2i2c/cluster.yaml) contains most 2i2c hubs that do not have their own dedicated cluster.
    - These files have an entry for each hub, which contains a **Zero to JupyterHub configuration** for your hub. You should find this configuration under `config/jupyterhub:`.
 2. **Your helm chart template**. In addition to your hub-specific configuration, your hub also has a "template configuration" that defines the basic setup of your hub infrastructure.
    Each template has a name (e.g., `dask-hub`) and maps onto a Helm configuration.


### PR DESCRIPTION
This makes a few re-names of `pilot` -> `docs`

closes #125 