### PR TITLE
Update pricing guide

### DIFF
--- a/_static/custom.css
+++ b/_static/custom.css
@@ -1,0 +1,4 @@
+/* Tables */
+table.align-middle td {
+  vertical-align: middle !important;
+}

--- a/about/pricing/comparison.md
+++ b/about/pricing/comparison.md
@@ -9,6 +9,90 @@ In each section below, we'll list a few similar companies and services that can 
 Their presence and ordering do not constitute an "endorsement" and are not exhaustive - we are merely trying to be transparent and helpful about the other organizations in this space.
 :::
 
+There are a few major categories to consider, and we'll provide a brief description of each below.
+
+- **Cloud cost**: How much does the infrastructure itself cost?
+- **Person cost**: How much time does it take to maintain, and how much does that time cost?
+- **Right to replicate**: Does the infrastructure run in a way that you could replicate the end-service nearly identically on your own?
+- **OSS Support**: Does this service reliably drive resources and support to open source communities that underlie the service?
+- **Scalable**: How complex is it to scale this option to many users, high-performance infrastructure, or big data?
+- **Customizable**: How much control do you have over the experience that your users have? Can you control the environment, interface, etc?
+- **Resilient**: Is this option vulnerable to bottlenecks in individual skills and capacity, or is it fault-tolerant and sustained by a group?
+
+Below is a short table summarizing the information below along a few major dimensions.
+It makes some simplifications and assumptions, and is meant to be a quick and "glanceable" way to compare the options below:
+
+::::{grid} 3
+:margin: 1
+
+:::{grid-item}
+✅ = yes / easy
+:::
+:::{grid-item}
+🟧 = sometimes / possible
+:::
+:::{grid-item}
+❌ = rarely / difficult
+:::
+::::
+
+:::{list-table}
+:widths: 15 10 10 5 5 5 5 5
+:class: align-middle
+:stub-columns: 1
+:header-rows: 1
+
+- - Service
+  - Cloud Cost
+  - Person Cost
+  - Right to Replicate
+  - OSS Support
+  - Scalable
+  - Customizable
+  - Resilient
+- - [2i2c](compare:2i2c)
+  - 💲💲
+  - 💲💲
+  - ✅
+  - ✅
+  - ✅
+  - ✅
+  - ✅
+- - [Internal Staffing](compare:internal)
+  - 💲💲💲
+  - 💲💲💲💲
+  - 🟧
+  - 🟧
+  - ❌
+  - ✅
+  - ❌
+- - [National infrastructure](compare:public-infra)
+  - 💲💲
+  - 💲💲💲
+  - 🟧
+  - 🟧
+  - 🟧
+  - 🟧
+  - 🟧
+- - [Consultancy](compare:consulting)
+  - 💲💲
+  - 💲💲💲
+  - 🟧
+  - 🟧
+  - ❌
+  - ✅
+  - 🟧
+- - [SaaS Products](compare:saas)
+  - 💲💲💲
+  - 💲
+  - ❌
+  - 🟧
+  - ✅
+  - ❌
+  - ✅
+:::
+
+(compare:2i2c)=
 ## How to think about 2i2c's service and pricing
 
 As a non-profit, we choose our prices to move forward on a sustainable path to achieve our mission according to [our cost model](costs:human) as well as [our growth model](strategy:growth).
@@ -20,9 +104,10 @@ We curate and integrate this infrastructure, customize it for use-cases in resea
 We use shared configuration and deployment infrastructure so that we can achieve economies of scale in serving many communities, but with an entirely open-source stack that can be customized for their unique needs.
 
 We do not know of any other organizations that offer managed cloud services in this way.
-However, below are three similar kinds of service and product models.
+However, below are a few similar kinds of service and product models.
 They are roughly ordered from "most similar" to "least similar" to 2i2c.
 
+(compare:internal)=
 ## Internal staffing
 
 The most common way for organizations to achieve similar services is to staff their own internal teams.
@@ -46,6 +131,19 @@ If you need to build this expertise internally, it is likely much more cost-effe
 We constantly adjust our own prices and team compensation to be responsive to the ecosystem of Cloud and Site Reliability Engineering, and we'll update this information as the field evolves.
 :::
 
+(compare:public-infra)=
+## Large-scale public infrastructure
+
+Depending on the state or country that you live in, there may also be options available to get access to large-scale shared infrastructure that is run by government agencies.
+For example, the [XSEDE](https://www.xsede.org/) program in the United States provides shared infrastructure that you can access with an application.
+
+The biggest challenges to using these larger infrastructure services tend to be inflexibility and friction associated with gaining access, sharing access, and customizing to your needs. Large-scale infrastructure efforts often come with significant complexity in bureaucratic process and steps that must be followed before you can get access.
+This is particularly difficult if you wish to collaborate across institutions, or want to easily provide access to newcomers.
+Moreover, the infrastructure tends to evolve more slowly, and is less dynamic in user interactions, than modern cloud-based infrastructure.
+Often you will need to adapt your workflow to the infrastructure setup, rather than the other way around.
+However, if you can find large-scale public infrastructure that accomplishes what you want, it may be a good option!
+
+(compare:consulting)=
 ## Consulting companies
 
 Many companies specialize in technical consulting that is flexible and tailored to an organization's needs.
@@ -58,6 +156,7 @@ It is difficult to assess the total number of hours needed to develop and operat
 If we assume 10 hours a month, this comes to between $1500 and $4000 a month.
 A more conservative estimate for a team that does not specialize in JupyterHub and Kubernetes infrastructure might be 30 hours a month, or between $4,500 and $12,000 a month.
 
+(compare:saas)=
 ## Software as a Service Products
 
 There are many companies offering services and platforms via a subscription fee.

--- a/about/pricing/index.md
+++ b/about/pricing/index.md
@@ -20,7 +20,7 @@ The sections below describe the strategy around our sustainability and pricing m
 It is a living document, and we will continue to update it as we learn more.
 
 ```{toctree}
-costs
 strategy
+costs
 comparison
 ```

--- a/about/pricing/strategy.md
+++ b/about/pricing/strategy.md
@@ -4,9 +4,20 @@ This page describes the rationale and strategy behind our pricing.
 
 We invite comments and feedback about the attractiveness and sustainability of these services, and expect to update this model with feedback from the community as we learn more.
 
+```{list-table}
+:widths: auto
+:stub-columns: 1
+
+- - Last Updated
+  - 2022-05-06
+- - Next checkpoint
+  - 2022-08
+```
+
 ## Guiding principles of our prices
 
 The following principles guide our decision-making around pricing our services.
+We believe that following these principles allows us to deliver the best services for our communities in a way that aligns with our mission and values.
 Our prices should:
 
 - Sustain and grow 2i2c's services and allow it to thrive as an organization.
@@ -14,6 +25,7 @@ Our prices should:
 - Reflect a holistic understanding of open source support, not just code.
 - Be competitive with other "Data Science environment as a service" offerings (see below for how we consider ourselves relative to similar offerings).
 - Be sustainable for the communities we serve, with mechanisms to accommodate institutions with fewer resources.
+
 
 ## Base fees for three service types
 
@@ -35,7 +47,7 @@ Below is a table which summarizes these major points
 
 ### Markup for running on dedicated clusters
 
-In general we want our fees to scale with the amount of complexity that we have to manage. If we run JupyterHubs on community-specific cloud infrastructure, we have more responsibility and moving parts to keep track of. For example, we’ll need to manage credentials for their cloud accounts, set up infrastructure that connects with those accounts, and manage a dedicated kubernetes cluster for them. We’ll also need to provide billing reports per-cluster for cloud costs. All of this is extra complexity we must deal with, and so a 50% markup is a conservative estimate to cover this labor.
+In general we want our fees to scale with the amount of complexity that we have to manage. If we run JupyterHubs on community-specific cloud infrastructure, we have more responsibility and moving parts to keep track of. For example, we’ll need to manage credentials for cloud accounts, set up infrastructure that connects with those accounts, and manage a dedicated kubernetes cluster for the community. We’ll also need to provide billing reports per-cluster for cloud costs. All of this is extra complexity we must deal with, and so a 50% markup is a conservative estimate to cover this labor.
 
 ## What we are missing
 
@@ -47,5 +59,5 @@ Below are a few things that we know we are missing:
 - **Lightweight hubs**. For many individuals or communities, these offerings might involve more complexity than what they need. We’d like to offer a much more scalable and lightweight hub service that people could quickly spin up. We hope to prototype and experiment with ideas after the initial roll-out of the alpha service.
 - **Communities that need multiple hubs**. For organizations with many sub-communities and complexity, a single hub is likely not enough to meet their needs. These communities may be better-served by their own dedicated federation of hubs, with a different pricing / growth model than the offerings described here. For now we’ll treat these as partnership opportunities, but may wish to standardize this in a service offering in the future.
 - **Significant differences in community size**. Our pricing model assumes that most communities have a relatively similar degree of complexity and size between them. However, when communities grow to a certain size (say, two orders of magnitude), it generates additional work in supporting users and hub operations. We hope to better-understand the costs associated with serving these larger communities, and identify ways to recover them via our pricing.
-- **Billing as a service**. In some cases we are managing the billing infrastructure and payments for communities. However, we do not currently charge explicitly for performing this service. We should estimate how much work and liability is entailed in this, and work with our fiscal sponsor to understand if and how much we should charge to cover these costs.
-- **Liability for cloud billing**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We should also explore potential ways to mitigate this risk (for example, pre-billing communities for *estimated* cloud usage to create a buffer, or asking for a deposit.
+- **Cloud payments as a service**. In some cases we manage the billing infrastructure and payments for communities (as opposed to them paying cloud providers directly). We do not currently charge explicitly for performing this service. In this case we take on extra work and complexity in tracking and paying cloud bills. We should estimate how much work and risk/liability is entailed in this, and work with our fiscal sponsor to understand how to cover these costs.
+- **Liability for cloud payments**. For communities where we manage their cloud billing, we hold some liability because we’ll need to pay the cloud provider for their usage before they pay us. We should work with our fiscal sponsor to understand our risk here (for example, what if a community charges $50,000 in cloud costs and then refuses to pay their invoice). We should also explore potential ways to mitigate this risk (for example, pre-billing communities for *estimated* cloud usage to create a buffer, or asking for a deposit.


### PR DESCRIPTION
This provides a few updates to our pricing guide after helpful feedback from folks at CS&S, including some directors of other projects. It:

- Adds a summary table at the top of our comparisons page
- Adds another comparison example, large-scale publicly-funded infrastructure
- Cleans up some language to be a bit more outward-facing after some feedback we got