### PR TITLE
DOCS: Add security section

### DIFF
--- a/about/overview.md
+++ b/about/overview.md
@@ -116,6 +116,7 @@ Check out [](../admin/howto/replicate.md) for information about replicating a 2i
 distributions/index
 shared-responsibility
 roles
+security
 ../new-hub
 2i2c
 ```

--- a/about/security.md
+++ b/about/security.md
@@ -1,0 +1,26 @@
+# Security and Abuse
+
+The cloud infrastructure that we manage follows best-practices in deploying cloud applications in a secure manner.
+This page describes a few ways in which we make our hubs more secure and prevent them from abuse.
+
+## Secure out of the box
+
+The [Zero to JupyterHub Helm Chart](https://zero-to-jupyterhub.readthedocs.io/en/latest/) is the community standard in deploying JupyterHub in the cloud, and is what 2i2c uses in all of its cloud hubs.
+This project follows the principle of "secure by default", and has a number of configuration and design decisions that properly isolate user environments from one another, and prevent them from being able to access resources or data that is forbidden to them.
+
+As members of the JupyterHub team, we are constantly looking for ways to improve [the security of Zero to JupyterHub](https://zero-to-jupyterhub.readthedocs.io/en/latest/administrator/security.html), and use our experience running these hubs to further improve JupyterHub's security.
+
+## Cryptocurrency mining
+
+Cryptocurrency mining abuse occurs when users take advantage of cloud CPU in order to make money by mining cryptocurrency.
+It is a common problem with cloud-based services and platforms.
+
+There are many different cryptocurrencies out there, but the most common by-far for abuse is [the Monero cryptocurrency](https://www.getmonero.org/) due to its anonymous nature.
+
+We deploy an open-source tool called [`cryptnono`](https://github.com/yuvipanda/cryptnono) to each of the clusters we manage.
+This tool monitors any process that runs on the 2i2c hubs, and automatically kills any that are associated with Monero.
+
+## Usage monitoring
+
+We deploy [Grafana Dashboards](https://grafana.com/grafana/dashboards/) along with a [Prometheus Server](https://prometheus.io/) to continuously monitor the usage across all of our hubs.
+This provides visual dashboards that allow us to identify abnormal behavior on a hub (such as a single user using unusual amounts of RAM, using a lot of CPU, or making unusual networking requests).


### PR DESCRIPTION
This is a first-pass at adding a lightweight "security and abuse" section to our service documentation. This should explain some of the things that we do to ensure that our hubs are secure and that they aren't vulnerable to abuse.

As a start, I listed three things here, but I'd love suggestions on other major security items I can mention in addition to this.