### PR TITLE
Revert name of service

### DIFF
--- a/about/infrastructure/index.md
+++ b/about/infrastructure/index.md
@@ -1,6 +1,6 @@
 # Infrastructure and features
 
-These sections contain information about the technical and cloud infrastructure behind the {term}`Collaborative JupyterHub Service`.
+These sections contain information about the technical and cloud infrastructure behind the {term}`Managed JupyterHub Service`.
 They describe the major technologies that are used, what kinds of use-cases and workflows are possible, as well as some important considerations that may be relevant to your community.
 
 ```{toctree}

--- a/about/service/index.md
+++ b/about/service/index.md
@@ -1,7 +1,7 @@
 (about-the-project)=
 # Overview of the service
 
-This section describes a high-level overview of our {term}`Collaborative JupyterHub Service` and the major teams, processes, and expectations around this service for both 2i2c and the partner community we work with.
+This section describes a high-level overview of our {term}`Managed JupyterHub Service` and the major teams, processes, and expectations around this service for both 2i2c and the partner community we work with.
 This page provides some high-level information to help you get started, and the sections below go into more detail on our service model and structure.
 
 ```{toctree}
@@ -21,7 +21,7 @@ Send us an email.
 ## What is the hub service?
 
 ```{glossary}
-Collaborative JupyterHub Service
+Managed JupyterHub Service
   An open, scalable, sustainable cloud service for interactive computing environments in research and education.
   It follows a "DevOps as a Service" model where communities in research and education can pay for managed cloud infrastructure that runs on an entirely open source stack, and give you [the right to replicate your infrastructure](https://2i2c.org/right-to-replicate).
 
@@ -32,7 +32,7 @@ Collaborative JupyterHub Service
 
 ## Who is this service for?
 
-2i2c's Collaborative JupyterHub Service is designed for communities in research and education who want the following things:
+2i2c's Managed JupyterHub Service is designed for communities in research and education who want the following things:
 
 1. Access to the latest technology in Jupyter and interactive computing for collaborative and scalable data science running in the cloud.
 2. To utilize open source, community-driven tools and standards.

--- a/about/service/team.md
+++ b/about/service/team.md
@@ -1,12 +1,12 @@
 (about/roles-for-service)=
 # Team structure and roles
 
-The Collaborative JupyterHub Service is a **collaborative cloud service** run in partnership with the communities that we serve.
+The Managed JupyterHub Service is a **collaborative cloud service** run in partnership with the communities that we serve.
 This page describes the major teams and roles that are involved in running this service.
 
 ## Teams and key stakeholders
 
-The Collaborative JupyterHub Service is composed of a {term}`Service Team` along with three sub-teams.
+The Managed JupyterHub Service is composed of a {term}`Service Team` along with three sub-teams.
 
 ```{figure} https://drive.google.com/uc?export=download&id=16r5xE7SguunLfMh5LhSynSUfjb7IXs_n
 An overview of the major teams that collaborate around the cloud service in order to serve a community of users. There are three main teams, and this diagram shows the major traits of each team, as well as a few ways in which they interact with one another.
@@ -15,7 +15,7 @@ An overview of the major teams that collaborate around the cloud service in orde
 ### Service team structure
 
 ```{glossary}
-Collaborative JupyterHub Service Team
+Managed JupyterHub Service Team
 Service Team
   The group of people that collaborate together to run a collaborative cloud service. It is comprised of three major sub-teams:
 

--- a/about/support/index.md
+++ b/about/support/index.md
@@ -1,6 +1,6 @@
 # User and community support
 
-As a part of the {term}`Collaborative JupyterHub Service`, we define two different kinds of user-support.
+As a part of the {term}`Managed JupyterHub Service`, we define two different kinds of user-support.
 Documentation about each can be found at the links below.
 
 - **Change requests and incidents** are discussions around making changes to infrastructure in order to improve the hub service for users or to resolve outages.

--- a/index.md
+++ b/index.md
@@ -1,6 +1,6 @@
 # Service Guide
 
-This is the primary documentation for 2i2c's Collaborative JupyterHub Service.
+This is the primary documentation for 2i2c's Managed JupyterHub Service.
 It is the primary source of information about the service, though some service documentation can be found on other sites.
 
 Check out the links above in order to navigate across various 2i2c documentation resources, and see the links below for some explanations and pointers.
@@ -9,7 +9,7 @@ Check out the links above in order to navigate across various 2i2c documentation
 
 Documentation about this service is split in three primary locations:
 
-- [`docs.2i2c.org`](https://docs.2i2c.org): An overview of the Collaborative JupyterHub Service, as well as documentation that is relevant to {term}`Service Team` members that are outside of 2i2c (such as JupyterHub Administration, User Guides, Pricing, etc). This is most service documentation.
+- [`docs.2i2c.org`](https://docs.2i2c.org): An overview of the Managed JupyterHub Service, as well as documentation that is relevant to {term}`Service Team` members that are outside of 2i2c (such as JupyterHub Administration, User Guides, Pricing, etc). This is most service documentation.
 - [`team-compass.2i2c.org/managed-hubs/index`](https://team-compass.2i2c.org/managed-hubs/index): Documentation about {term}`Service Team` processes that are primarily relevant to 2i2c team members. We put this documentation here to prevent [`docs.2i2c.org`](https://docs.2i2c.org) from getting too cluttered.
 - [`infrastructure.2i2c.org`](https://infrastructure.2i2c.org): Our {term}`Cloud Engineering Team` and cloud infrastructure documentation.
 


### PR DESCRIPTION
Just a standard search and replace for renaming
'managed hub' to 'collaborative hub' in
https://github.com/2i2c-org/docs/pull/148,
until we figure out what to call it.

Ref https://github.com/2i2c-org/infrastructure/issues/1473

closes https://github.com/2i2c-org/infrastructure/issues/1474