### PR TITLE
Add several basic policies for the 2i2c hubs

### DIFF
--- a/index.md
+++ b/index.md
@@ -22,6 +22,7 @@ These sections describe the hub service at an organizational level.
 :caption: About the service
 about/service/index
 about/infrastructure/index
+policy/index
 about/support/index
 about/sustainability/index
 about/strategy/index

--- a/policy/acceptable-use.md
+++ b/policy/acceptable-use.md
@@ -1,0 +1,32 @@
+# Acceptable Use Policy
+
+:::{admonition} This is not a legal document
+:class: warning
+This document is provided to set expectations and understanding about 2i2c's cloud infrastructure service.
+It is not legally binding.
+:::
+
+This document describes a few expectations that we have of anybody using a 2i2c Managed Infrastructure. They are guidelines to ensure that the infrastructure is used in a responsible and safe manner for all.
+## Terminology
+
+2i2c Managed Infrastructure: Any web service, program, or cloud infrastructure that 2i2c manages on behalf of a user’s community.
+
+## Acceptable Use Policy
+
+This policy does not nullify any part of the Acceptable Use Policies that apply to your community (e.g., university Acceptable Use Policies).
+In addition you must comply with the policies and guidelines for any specific set of resources to which you have been granted access (e.g., policies from Cloud Providers).
+When other policies are more restrictive than this policy, the more restrictive policy takes precedence.
+
+- You may use only the 2i2c Managed Infrastructure and accounts for which you have authorization.
+- You may not use another individual's account, or attempt to capture or guess other users' passwords.
+  You may not enable unauthorized users to access infrastructure managed by 2i2c by providing them access to your account.
+- You are individually responsible for appropriate use of all resources provided to you, including your interactive computing session, networking infrastructure on your hub, and the software and hardware you use.
+- 2i2c is bound by its contractual and license agreements respecting certain third party resources; you are expected to comply with all such agreements when using such resources.
+- You should make a reasonable effort to protect your passwords and to secure resources against unauthorized use or access.
+  Where applicable you must configure access to other cloud services or data in a way that reasonably prevents unauthorized users from accessing them.
+- You must not attempt to access restricted portions of the network or any 2i2c Managed Infrastructure without appropriate authorization by a 2i2c engineer.
+- You must not use 2i2c Managed Infrastructure and/or network resources in conjunction with the execution of programs, software, processes, or automated transaction-based commands that are intended to disrupt (or that could reasonably be expected to disrupt) other computer or network users, or damage or degrade performance, software or hardware components of a system.
+- Do not use the 2i2c Managed Infrastructure to distribute or facilitate the sending of unsolicited or unlawful (i) email or other messages, or (ii) promotions of any kind;
+- Do not use the 2i2c Managed Infrastructure to engage in or promote any other fraudulent, deceptive or illegal activities.
+- Do not use the 2i2c Managed Infrastructure to process, store or transmit material, including any Customer Data, in violation of any Law or any third party rights, including without limitation privacy rights;
+- Do not use the 2i2c Managed Infrastructure in any circumstances where failure could lead to death, personal injury or environmental damage, and you further acknowledge that the 2i2c Managed Infrastructure is not designed or intended for such use.

--- a/policy/acceptable-use.md
+++ b/policy/acceptable-use.md
@@ -25,6 +25,7 @@ When other policies are more restrictive than this policy, the more restrictive 
 - You should make a reasonable effort to protect your passwords and to secure resources against unauthorized use or access.
   Where applicable you must configure access to other cloud services or data in a way that reasonably prevents unauthorized users from accessing them.
 - You must not attempt to access restricted portions of the network or any 2i2c Managed Infrastructure without appropriate authorization by a 2i2c engineer.
+- You must not attempt to use 2i2c Managed Infrastructure for the purposes of [mining cryptocurrencies](https://en.wikipedia.org/wiki/Cryptocurrency#Mining) unless explicitly given permission by a {term}`Community Representative` for research purposes.
 - You must not use 2i2c Managed Infrastructure and/or network resources in conjunction with the execution of programs, software, processes, or automated transaction-based commands that are intended to disrupt (or that could reasonably be expected to disrupt) other computer or network users, or damage or degrade performance, software or hardware components of a system.
 - Do not use the 2i2c Managed Infrastructure to distribute or facilitate the sending of unsolicited or unlawful (i) email or other messages, or (ii) promotions of any kind;
 - Do not use the 2i2c Managed Infrastructure to engage in or promote any other fraudulent, deceptive or illegal activities.

--- a/policy/code-of-conduct.md
+++ b/policy/code-of-conduct.md
@@ -1,0 +1,3 @@
+# Code of Conduct
+
+See [2i2c's code of conduct](tc:code-of-conduct.md) for our Code of Conduct.

--- a/policy/index.md
+++ b/policy/index.md
@@ -1,0 +1,10 @@
+# Policies
+
+We have a few policies for both 2i2c and the communities that we work with.
+These describe the expectations and rules around the service.
+
+```{toctree}
+code-of-conduct
+acceptable-use
+privacy
+```

--- a/policy/privacy.md
+++ b/policy/privacy.md
@@ -1,0 +1,27 @@
+# Privacy Policy
+
+:::{admonition} This is not a legal document
+:class: warning
+This document is provided to set expectations and understanding about 2i2c's cloud infrastructure service.
+It is not legally binding.
+:::
+
+## Summary
+
+2i2c does not retain any identifiable information about its users or the information they create or place in the infrastructure we run.
+We require _access_ to the information our infrastructure while it is running, but do not retain this information when we stop working with a community.
+
+## While we run infrastructure
+
+- 2i2c's engineering team requires access to the filesystems of any user on our infrastructure for debugging and maintenance purposes.
+  - We do not retain or share this information for any purpose.
+- 2i2c may have access to personally-identifiable information that is used for _authenticating_ users (e.g. e-mail log-ins).
+  - We do not retain or share this information for any purpose.
+- We do not change or delete any user data on a hub without the consent of the hub's Community Representative.
+- We collect aggregate statistics about general _usage_ of the infrastructure for monitoring and alerting purposes (e.g., number of active users each hour).
+
+## After we stop working with a community
+
+- When we stop working with a community, we will delete all information, data, etc that was contained within the community's infrastructure.
+- We do not retain any identifiable information that was provided as part of running a community's infrastructure.
+- The community retains access to their own cloud and data infrastructure, and we will give up our own access.

--- a/policy/privacy.md
+++ b/policy/privacy.md
@@ -17,7 +17,7 @@ We require _access_ to the information our infrastructure while it is running, b
   - We do not retain or share this information for any purpose.
 - 2i2c may have access to personally-identifiable information that is used for _authenticating_ users (e.g. e-mail log-ins).
   - We do not retain or share this information for any purpose.
-- We do not change or delete any user data on a hub without the consent of the hub's Community Representative.
+- We do not change or delete any user data on a hub without the consent of the hub's {term}`Community Representative`.
 - We collect aggregate statistics about general _usage_ of the infrastructure for monitoring and alerting purposes (e.g., number of active users each hour).
 
 ## After we stop working with a community

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 sphinx
 sphinx-autobuild
 sphinx-copybutton
-git+https://github.com/2i2c-org/sphinx-2i2c-theme
+sphinx-2i2c-theme --pre
 sphinx-design
 sphinxext-rediraffe
 tabulate


### PR DESCRIPTION
This adds three policies to our infrastructure documentation. We've discussed each of them over time but hadn't yet put them in a public place. I believe that we still need to improve them all, and in some cases may need a lawyer to give an official stamp of approval, so for now I have noted each of them as non-legally-binder policies that are there to set expectations.

Unclear if we can close out any of these issues so I'll cross-ref them below:

- ref: https://github.com/2i2c-org/infrastructure/issues/342
- ref: https://github.com/2i2c-org/docs/issues/139
- ref: https://github.com/2i2c-org/team-compass/issues/388