### PR TITLE
Fix the install path for our 2i2c theme

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,7 +6,7 @@ requests
 sphinx
 sphinx-autobuild
 sphinx-copybutton
-sphinx-2i2c-theme --pre
+git+https://github.com/2i2c-org/sphinx-2i2c-theme
 sphinx-design
 sphinxext-rediraffe
 tabulate


### PR DESCRIPTION
For some reason this was installing our 2i2c theme with `sphinx-2i2c-theme --pre`, but we haven't made any releases for this theme to my knowledge so this wasn't working. I think it was an accidental change from https://github.com/2i2c-org/docs/pull/161

I'll merge this if readthedocs passes since right now our docs are broken!