### PR TITLE
Fix redirects and links

### DIFF
--- a/admin/howto/new-hub.md
+++ b/admin/howto/new-hub.md
@@ -28,7 +28,7 @@ Send us an email
 
 The Community Representative is the main point of contact between the community and the 2i2c Engineering Team.
 There can be up to two Community Representatives per hub.
-See [](about/roles-for-service) for more details on this role.
+See [](../../about/service/shared-responsibility.md) for more details on this role.
 
 ## Fill in the "New Hub" GitHub template
 

--- a/conf.py
+++ b/conf.py
@@ -61,9 +61,13 @@ intersphinx_mapping = {
 }
 
 rediraffe_redirects = {
+    # Added around 2022-09
     "about/overview.md": "about/service/index.md",
-    "about/service/roles.md": "about/service/team.md",
     "about/pricing/index.md": "about/service/options.md",
+
+    # Added 2022-11-29
+    "about/service/roles.md": "about/service/shared-responsibility.md",
+    "about/service/team.md": "about/service/shared-responsibility.md",
 }
 
 # Disable linkcheck for anchors because it throws false errors for any JS anchors


### PR DESCRIPTION
Fixes some minor redirects and links that ReadTheDocs surfaced.

Will self merge this one since it's quite tiny