### PR TITLE
Note that gh-scoped-creds only works with HTTPS url

### DIFF
--- a/data/git.md
+++ b/data/git.md
@@ -17,7 +17,7 @@ import gh_scoped_creds
 ```
 
 You should now be able to push to GitHub from the hub! 
-> Make sure to use the HTTPS url to repos, not the SSH one.
+> Make sure to use the HTTPS url to clone from and push to repos, not the SSH one!
 
 These credentials will expire after
 8 hours (or whenever your JupyterHub server stops), and you'll have to repeat these steps

--- a/data/git.md
+++ b/data/git.md
@@ -16,7 +16,10 @@ import gh_scoped_creds
 %ghscopedcreds
 ```
 
-You should now be able to push to GitHub from the hub! These credentials will expire after
+You should now be able to push to GitHub from the hub! 
+> Make sure to use the HTTPS url to repos, not the SSH one.
+
+These credentials will expire after
 8 hours (or whenever your JupyterHub server stops), and you'll have to repeat these steps
 to fetch a fresh set of credentials. Once you authenticate, you'll be provided with a link
 to a [GitHub App](https://docs.github.com/en/developers/apps/getting-started-with-apps/about-apps)


### PR DESCRIPTION
Maybe the wording could be improved, but I think its important to point this out here.