### PR TITLE
Automatically add readthedocs preview links to PR descriptions

### DIFF
--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -7,11 +7,12 @@ on:
     branches:
       - main
 
+permissions:
+  pull-requests: write
+
 jobs:
   autolink-rtd-previews:
     runs-on: ubuntu-latest
-    permissions:
-      pull-requests: write
     steps:
       - uses: readthedocs/actions/preview@v1
         with:

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,12 +1,10 @@
 name: Add readthedocs preview link to pull requests
 
 on:
-  pull_request:
+  pull_request_target:
     types:
       - opened
       - reopened
-    branches:
-      - main
 
 permissions:
   pull-requests: write

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -1,0 +1,19 @@
+name: Add readthedocs preview link to pull requests
+
+on:
+  pull_request:
+    types:
+      - opened
+    branches:
+      - main
+
+jobs:
+  autolink-rtd-previews:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: readthedocs/actions/preview@v1
+        with:
+          # The project slug in RTD still has the old repo name
+          project-slug: "2i2c-pilot-documentation"

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -2,9 +2,6 @@ name: Add readthedocs preview link to pull requests
 
 on:
   pull_request_target:
-    types:
-      - opened
-      - reopened
 
 permissions:
   pull-requests: write

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -4,6 +4,7 @@ on:
   pull_request:
     types:
       - opened
+      - reopened
     branches:
       - main
 

--- a/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
+++ b/.github/workflows/autolink-readthedocs-previews-to-prs.yaml
@@ -3,12 +3,11 @@ name: Add readthedocs preview link to pull requests
 on:
   pull_request_target:
 
-permissions:
-  pull-requests: write
-
 jobs:
   autolink-rtd-previews:
     runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
     steps:
       - uses: readthedocs/actions/preview@v1
         with:


### PR DESCRIPTION
This PR adds a GitHub Action workflow that will automatically add readthedocs preview link to Pull Request descriptions, making viewing rendered changes more accessible. An example PR is here: https://github.com/sgibson91/test-multilingual-sphinx/pull/4