### PR TITLE
Bump readthedocs python version

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -6,8 +6,7 @@ version: 2
 build:
   os: ubuntu-20.04
   tools:
-    # The sphinx-2i2c-theme requires python >= 3.8
-    python: "3.8"
+    python: "3.12"
     nodejs: "16"
 
 sphinx:


### PR DESCRIPTION
This should allow us to build our documentation with the latest versions of things now that 3.8 is no longer supported by many packages.

<!-- readthedocs-preview 2i2c-pilot-documentation start -->
----
📚 Documentation preview 📚: https://2i2c-pilot-documentation--202.org.readthedocs.build/en/202/

<!-- readthedocs-preview 2i2c-pilot-documentation end -->