### PR TITLE
Add note about configurator not working when having profile lists

### DIFF
--- a/admin/howto/configurator.md
+++ b/admin/howto/configurator.md
@@ -4,6 +4,12 @@ The [JupyterHub configurator](https://github.com/yuvipanda/jupyterhub-configurat
 allows admins to change a subset of hub settings without requiring involvement
 from 2i2c engineers.
 
+```{attention}
+If the hub has profile lists enabled that override the same hub settings as the configurator, then any change done with the configurator will have no effect, because of the complexity of having more than one profile option.
+
+See [](unlisted-image) instead in this case.
+```
+
 ```{warning}
 Be careful while changing these settings! We don't expose anything that can
 make the hub inaccessible to *admins*, but you can still change things that

--- a/user/howto/specify-unlisted-image.md
+++ b/user/howto/specify-unlisted-image.md
@@ -1,3 +1,4 @@
+(unlisted-image)=
 # Starting and customizing the software environment of a user server
 
 To start a server on the Hub, you need to go to the hub's home page, then click on the `Start My server button`.


### PR DESCRIPTION
There is still confusion around this with the communities: https://2i2c.freshdesk.com/a/tickets/1233

<!-- readthedocs-preview 2i2c-pilot-documentation start -->
----
📚 Documentation preview 📚: https://2i2c-pilot-documentation--204.org.readthedocs.build/en/204/

<!-- readthedocs-preview 2i2c-pilot-documentation end -->