### PR TITLE
Update broken links in pricing and service docs 

### DIFF
--- a/about/service/options.md
+++ b/about/service/options.md
@@ -1,5 +1,5 @@
 (service-offerings)=
-# Usecases and prices
+# Use cases and prices
 
 Our Hub Service is an open, scalable, sustainable cloud service for interactive computing environments.
 We offer cloud infrastructure hubs that are designed for use-cases in research and education, and flexible enough to be tailored to the needs of each community.
@@ -7,15 +7,8 @@ We offer cloud infrastructure hubs that are designed for use-cases in research a
 They run entirely on community-driven and open-source infrastructure,
 follow a [community-centric collaborative service model](./index.md), and give you [the right to replicate your infrastructure](https://2i2c.org/right-to-replicate).
 
-A table summarizing our services and their prices are at the link below.
-The rest of the pages in this section describe the cloud services that we offer and the use-cases they are designed for.
 See [](./index.md) for more about our collaborative service model.
 
-```{button-link} https://docs.google.com/document/d/1FNiDyKNDoe_TgU2WxuNZ5CayYD56tlNJpImQsAIGOmg/edit?usp=sharing
-:color: primary
-
-Our service offerings and prices
-```
 
 ## An overview of our infrastructure
 
@@ -25,7 +18,7 @@ The section below provides an overview of our infrastructure and the technical f
 ../distributions/index.md
 ```
 
-## Education use-cases
+## Education use cases
 
 JupyterHub is excellent for educational use-cases, such as providing a cloud-based learning environment for large-scale data science teaching or domain-specific cloud-enabled science.
 
@@ -33,7 +26,7 @@ JupyterHub is excellent for educational use-cases, such as providing a cloud-bas
 ../distributions/education
 ```
 
-## Research use-cases
+## Research use cases
 
 JupyterHub is an excellent gateway to cloud-based resources and data analytics environments.
 It can be used as a part of distributed scientific collaborations, scientific communities with cloud-based worklfows, and scalable analytics environments for research teams.


### PR DESCRIPTION
I've removed some links to ancient service descriptions and outdated pricing. I made small edits to section headings to be more consistent. This is a fast edit driven by confusion surfaced by Chrys Wu (IOI).