### PR TITLE
Document image building lack of content files and minor rearrangement

### DIFF
--- a/admin/billing/index.md
+++ b/admin/billing/index.md
@@ -1,0 +1,10 @@
+# Billing and cloud costs
+
+Information about monitoring and controlling the cloud costs for your hub, as well as setting up your own cloud accounts to power your infrastructure.
+
+```{toctree}
+:maxdepth: 2
+../howto/create-billing-account
+../../topic/cloud-costs
+../../topic/budget-alerts
+```

--- a/index.md
+++ b/index.md
@@ -24,16 +24,16 @@ They are meant for individuals who wish to learn about the service for their own
 about/service/options
 about/service/index
 user/topics/policy/index
-See a table of our running hubs! <https://infrastructure.2i2c.org/reference/hubs/>
+☁️ Table of running hubs <https://infrastructure.2i2c.org/reference/hubs/>
 ```
 
-## Use the hub
+## Hub users
 
 Covers end-user workflows that are common for cloud-native workflows with interactive computing.
 
 ```{toctree}
 :maxdepth: 2
-:caption: Use the hub
+:caption: Hub users
 
 user/topics/getting-started
 user/topics/data/index
@@ -42,14 +42,14 @@ community/content
 user/howto/launch-dask-gateway-cluster
 ```
 
-## Administer the hub
+## Hub administrators
 
 Information for those with the **hub administrator** role on a JupyterHub.
 These cover many things that you can do to manage and configure your hub and its infrastructure.
 
 ```{toctree}
 :maxdepth: 2
-:caption: Administer the hub
+:caption: Hub administrators
 
 support
 admin/howto/configurator
@@ -61,32 +61,19 @@ admin/topics/network
 admin/topics/managing-secrets
 ```
 
-## Community leadership
+## Community leaders
 
 Covers topics relevant to those that are leading others in a community.
 
 ```{toctree}
-:caption: Community leadership
-:maxdepth: 2
-
-community/events
-community/strategy
-```
-
-## Community representatives
-
-Documentation for those serving as _Community Representatives_.
-These tend to cover technical, administrative, invoicing, and collaborative processes for interacting with 2i2c's team on behalf of your community.
-
-```{toctree}
-:caption: Community representatives
+:caption: Community leaders
 :maxdepth: 2
 
 admin/howto/new-hub
+admin/billing/index
+community/events
+community/strategy
 admin/howto/replicate
-admin/howto/create-billing-account
-topic/cloud-costs
-topic/budget-alerts
 ```
 
 ## Reference material

--- a/noxfile.py
+++ b/noxfile.py
@@ -1,5 +1,6 @@
 import nox
 
+nox.options.default_venv_backend = "uv"
 nox.options.reuse_existing_virtualenvs = True
 
 build_command = ["-b", "dirhtml", ".", "_build/dirhtml"]

--- a/user/environment/dynamic-imagebuilding.md
+++ b/user/environment/dynamic-imagebuilding.md
@@ -93,6 +93,16 @@ Environment images are cached automatically, so if you give another hub user the
 
 Just update any of the files in your environment repository, and your environment will be re-built the next time you launch a session from it.
 
+### Why don't I see the files in my repository when I launch an environment?
+
+Dynamic environment image generation is **only for the software environment**, it does not include any content files in the environment that is created.
+
+:::{seealso}
+See [](#content:nbgitpuller) for ways to share content along with repositories.
+:::
+
+This is an important difference from [mybinder.org](https://mybinder.org). While Binder is designed for reproducibility, dynamic image generation is designed for users to quickly define software environments for their hubs. For this reason, Binder packages as much as it can in a single link (software, content, etc), while dynamic image building only includes the software environment.
+
 ### Can I use another community's pre-existing environment?
 
 Yes! That's often the simplest choice. See [this repo2docker guide on choosing an environment](https://repo2docker.readthedocs.io/en/latest/use/pathways/) for guidance.


### PR DESCRIPTION
Two quick things:

- resolves https://github.com/2i2c-org/infrastructure/issues/6587
- nests a few top-level pages under a "billing and cloud" section so the sidebar is less cluttered