### PR TITLE
Document GPU sharing and binderbot

### DIFF
--- a/user/environment/dynamic-imagebuilding.md
+++ b/user/environment/dynamic-imagebuilding.md
@@ -107,6 +107,11 @@ This is an important difference from [mybinder.org](https://mybinder.org). While
 
 Yes! That's often the simplest choice. See [this repo2docker guide on choosing an environment](https://repo2docker.readthedocs.io/en/latest/use/pathways/) for guidance.
 
+### Can I use this to verify my published notebooks still run correctly over time?
+
+Not directly, dynamic image building is for interactive sessions on the hub.
+See [](#user:notebook-ci) for running notebooks in CI on Binder instead.
+
 ### Where can I learn more about environment configuration and building?
 
 The [repo2docker user guide is the best place to learn more in general](https://repo2docker.readthedocs.io/en/latest/use/).

--- a/user/environment/index.md
+++ b/user/environment/index.md
@@ -7,6 +7,7 @@ There are a few ways that hub administrators can expose custom environments to t
 :maxdepth: 1
 choose.md
 dynamic-imagebuilding.md
+notebook-ci.md
 ```
 
 :::{admonition} Ask a hub administrator if these are not enabled

--- a/user/environment/notebook-ci.md
+++ b/user/environment/notebook-ci.md
@@ -1,0 +1,11 @@
+(user:notebook-ci)=
+# Run notebooks and Jupyter Books as part of your repository's CI/CD on Binder
+
+If you publish notebooks (e.g. in a MyST or Jupyter Book site) and want CI to confirm they still execute correctly over time, [BinderBot](https://2i2c.org/binderbot) is a GitHub Action and CLI that runs them on mybinder.org instead of the CI runner.
+
+:::{admonition} Example use by communities
+:class: seealso
+Project Pythia's [`cookbook-actions` workflow](https://github.com/ProjectPythia/cookbook-actions/blob/8ec8389666adab5d244a23e1b046bfb7b9bf3804/.github/workflows/build-book.yaml#L158-L163) uses BinderBot to execute their MyST cookbooks on Binder as part of CI.
+:::
+
+If you'd like help setting this up, [open a support request](../../support.md).

--- a/user/scalable-computing/gpu-sharing.md
+++ b/user/scalable-computing/gpu-sharing.md
@@ -1,0 +1,15 @@
+# GPU sharing
+
+On GCP, hubs can split a single GPU into smaller time-sliced shares, so more people get GPU access at once instead of needing a dedicated GPU per user. It's a good fit for teaching and other light GPU workloads.
+
+See [2i2c's blog post](https://2i2c.org/blog/more-users-fewer-gpus/) and the [GPU time-sharing setup guide](https://infrastructure.2i2c.org/howto/features/gpu/) for details.
+
+:::{admonition} For hub administrators
+:class: seealso
+To enable GPU sharing on your hub, [open a support request](../../support.md).
+:::
+
+:::{admonition} Example use by communities
+:class: seealso
+2i2c's [CloudBank Classroom hub config](https://github.com/2i2c-org/infrastructure/blob/49af1ed86c9819ecc6d29e9874030ba6ac862634/terraform/gcp/projects/cloudbank.tfvars#L398-L410) splits a T4 GPU node pool into 2 time-sliced shares, giving a whole class GPU access from a single node.
+:::

--- a/user/scalable-computing/index.md
+++ b/user/scalable-computing/index.md
@@ -2,4 +2,5 @@
 
 ```{toctree}
 launch-dask-gateway-cluster.md
+gpu-sharing.md
 ```


### PR DESCRIPTION
We've recently added support for two new kinds of features: GPU sharing and BinderBot, but we haven't documented it in a user-facing space. This adds a brief mention of each and tries to link out to other places for people to learn more.